### PR TITLE
fix: CI code-qualityジョブの修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run Biome lint check
-        run: bun run lint
-
-      - name: Run Biome format check  
-        run: bun run format
+      - name: Run Biome check (lint + format)
+        run: bun run check
 
       - name: Build application
         run: bun run build
@@ -32,7 +29,7 @@ jobs:
       - name: Type check
         run: |
           cd apps/frontend
-          bun run typecheck || bunx tsc --noEmit
+          bunx tsc --noEmit
 
   security:
     runs-on: ubuntu-latest

--- a/apps/backend/src/features/todo/todo-validation.test.ts
+++ b/apps/backend/src/features/todo/todo-validation.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'bun:test';
-import { 
-  createTodoSchema, 
-  updateTodoSchema, 
-  idParamSchema 
+import { describe, expect, it } from 'bun:test';
+import {
+  createTodoSchema,
+  idParamSchema,
+  updateTodoSchema,
 } from './todo.validation';
 
 describe('Todo バリデーションテスト', () => {
@@ -10,22 +10,22 @@ describe('Todo バリデーションテスト', () => {
     it('有効な Todo 作成入力を受け入れる', () => {
       const validInput = {
         title: 'テスト Todo',
-        description: 'テスト説明'
+        description: 'テスト説明',
       };
 
       const result = createTodoSchema.parse(validInput);
-      
+
       expect(result.title).toBe('テスト Todo');
       expect(result.description).toBe('テスト説明');
     });
 
     it('説明なしの Todo 作成入力を受け入れる', () => {
       const validInput = {
-        title: 'テスト Todo'
+        title: 'テスト Todo',
       };
 
       const result = createTodoSchema.parse(validInput);
-      
+
       expect(result.title).toBe('テスト Todo');
       expect(result.description).toBeUndefined();
     });
@@ -33,21 +33,23 @@ describe('Todo バリデーションテスト', () => {
     it('空のタイトルを拒否する', () => {
       const invalidInput = {
         title: '',
-        description: 'テスト説明'
+        description: 'テスト説明',
       };
 
-      expect(() => createTodoSchema.parse(invalidInput)).toThrow('Title is required');
+      expect(() => createTodoSchema.parse(invalidInput)).toThrow(
+        'Title is required'
+      );
     });
   });
 
   describe('updateTodoSchema バリデーション', () => {
     it('完了状態のみの部分更新入力を受け入れる', () => {
       const validInput = {
-        completed: true
+        completed: true,
       };
 
       const result = updateTodoSchema.parse(validInput);
-      
+
       expect(result.completed).toBe(true);
     });
 
@@ -55,7 +57,7 @@ describe('Todo バリデーションテスト', () => {
       const emptyInput = {};
 
       const result = updateTodoSchema.parse(emptyInput);
-      
+
       expect(result).toEqual({});
     });
   });
@@ -65,32 +67,40 @@ describe('Todo バリデーションテスト', () => {
       const validInput = { id: '123' };
 
       const result = idParamSchema.parse(validInput);
-      
+
       expect(result.id).toBe(123);
     });
 
     it('非数値文字列 ID を拒否する', () => {
       const invalidInput = { id: 'abc' };
 
-      expect(() => idParamSchema.parse(invalidInput)).toThrow('Invalid ID format');
+      expect(() => idParamSchema.parse(invalidInput)).toThrow(
+        'Invalid ID format'
+      );
     });
 
     it('ゼロの ID を拒否する', () => {
       const invalidInput = { id: '0' };
 
-      expect(() => idParamSchema.parse(invalidInput)).toThrow('Invalid ID format');
+      expect(() => idParamSchema.parse(invalidInput)).toThrow(
+        'Invalid ID format'
+      );
     });
 
     it('負の ID を拒否する', () => {
       const invalidInput = { id: '-5' };
 
-      expect(() => idParamSchema.parse(invalidInput)).toThrow('Invalid ID format');
+      expect(() => idParamSchema.parse(invalidInput)).toThrow(
+        'Invalid ID format'
+      );
     });
 
     it('小数点 ID を拒否する', () => {
       const invalidInput = { id: '12.5' };
 
-      expect(() => idParamSchema.parse(invalidInput)).toThrow('Invalid ID format');
+      expect(() => idParamSchema.parse(invalidInput)).toThrow(
+        'Invalid ID format'
+      );
     });
   });
 });

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -14,5 +14,5 @@
     "declaration": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/apps/frontend/jest.config.js
+++ b/apps/frontend/jest.config.js
@@ -5,10 +5,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  collectCoverageFrom: [
-    'src/**/*.{ts,js}',
-    '!src/**/*.d.ts',
-  ],
+  collectCoverageFrom: ['src/**/*.{ts,js}', '!src/**/*.d.ts'],
   preset: 'ts-jest/presets/default',
   extensionsToTreatAsEsm: ['.ts'],
   globals: {
@@ -16,4 +13,4 @@ module.exports = {
       useESM: true,
     },
   },
-}
+};

--- a/apps/frontend/src/lib/api-client.test.ts
+++ b/apps/frontend/src/lib/api-client.test.ts
@@ -4,7 +4,7 @@ describe('API クライアント ロジック', () => {
       const baseUrl = 'http://localhost:3001';
       const id = '123';
       const expectedUrl = `${baseUrl}/api/todos/${id}`;
-      
+
       expect(expectedUrl).toBe('http://localhost:3001/api/todos/123');
     });
 


### PR DESCRIPTION
## 概要
CI の code-quality ジョブが失敗していた問題を修正しました。

## 変更内容
- 🔧 Biome の `check` コマンドを使用するように変更（`lint` と `format` を統合）
- 📦 TypeScript ビルドからテストファイル（`*.test.ts`）を除外
- ✨ 既存コードのフォーマットエラーを自動修正

## 修正前の問題
1. CI で `bun run format` コマンドがフォーマットチェックとして機能していなかった
2. TypeScript ビルドでテストファイルのコンパイルエラーが発生していた（Bun test types が見つからない）

## テスト結果
- ✅ `bun run check` - 成功
- ✅ `bun run build` - 成功
- ✅ CI workflow - 全ジョブが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)